### PR TITLE
don't compile, install BioConductor binary packages instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,4 @@
-FROM ubuntu:20.04
-
-RUN apt-get update
-
-# Ubuntu 20.04 uses R 3.x, but we want to use R 4.x instead
-RUN apt-get -y install software-properties-common && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
-    add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/' && \
-    apt-get update && \
-    apt-get install r-base-core -y
-
-RUN apt-get install -y libssl-dev libcurl4-openssl-dev
+FROM bioconductor/bioconductor_docker:RELEASE_3_14
 
 # We'll copy setup.r and run it before copying all other files,
 # so that changing other R files doesn't cause unnecessary reinstalls

--- a/Program/setup.R
+++ b/Program/setup.R
@@ -1,16 +1,24 @@
 #setup script installing nescessary packages if not present
-packs = c("BiocManager", "igraph", "shiny", "readxl", "ggplot2")
-bcpacks = c("GO.db", "topGO")
+packages = c("graph", "igraph", "shiny", "readxl", "ggplot2", "remotes")
+bioc_packages = c("GO.db", "topGO")
 
-for (pack in packs) {
-  if(!(requireNamespace(pack, quietly=TRUE))) {
-    install.packages(pack)
+for (pkg in packages) {
+  if(!(requireNamespace(pkg, quietly=TRUE))) {
+    install.packages(pkg)
   }
 }
 
-for (bcpack in bcpacks) {
-  if(!(requireNamespace(bcpack, quietly=TRUE))) {
-    library(BiocManager)
-    BiocManager::install(bcpack)
+# Install bioconductor packages as binary packages
+# instead of compiling them locally. This should be
+# much faster.
+if(!require('AnVIL')) {
+  remotes::install_github("Bioconductor/AnVIL")
+  library('AnVIL')
+}
+
+for (bioc_pkg in bioc_packages) {
+  if(!(requireNamespace(bioc_pkg, quietly=TRUE))) {
+    library(AnVIL)
+    AnVIL::install(bioc_pkg)
   }
 }


### PR DESCRIPTION
* speeds up installation from [20m](https://github.com/Suiram23/GRN_web/actions/runs/2189486957) to [4.5m](https://github.com/Suiram23/GRN_web/actions/runs/2189819693)
* uses AnVIL instead of BiocManager to install Bioconductor packages