### PR TITLE
enable manual heroku deployment

### DIFF
--- a/.github/workflows/heroku.yml
+++ b/.github/workflows/heroku.yml
@@ -1,0 +1,29 @@
+# I was able to deploy manually using the following commands:
+#
+#    heroku container:login
+#    heroku container:push web
+#    heroku container:release web
+#    heroku open
+
+name: heroku_deploy
+on:
+  push:
+    branches:
+      - develop
+      - enh/deploy-to-heroku
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2        
+      - uses: akhileshns/heroku-deploy@v3.12.12
+        with: 
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: "grn-web"
+          heroku_email: ${{secrets.HEROKU_EMAIL}}
+          healthcheck: "https://grn-web.herokuapp.com/"
+          usedocker: true
+          delay: 60
+          rollbackonhealthcheckfailed: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,3 +14,13 @@ WORKDIR /opt/grn-web/Program
 
 # open port used by our shiny app (defined in app.R)
 EXPOSE 8181
+
+# set non-root (Heroku requires this)                   
+RUN useradd shiny_user
+# make all app files readable, gives rwe permisssion
+RUN chown -R shiny_user:shiny_user /opt/grn-web
+USER shiny_user
+
+# run app on container start (use heroku port variable for deployment)
+CMD ["R", "-e", "shiny::runApp('/opt/grn-web/Program', host = '0.0.0.0', port = as.numeric(Sys.getenv('PORT')))"]
+

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ run-bash:
 	docker run -v /tmp/grn-web:/tmp/grn-web -it grn-web bash
 
 run-shiny:
-	docker run -p 8181:8181 -it grn-web Rscript app.R
+	docker run --env PORT=8181 -p 8181:8181 -it grn-web
 
 test:
 	docker run -it grn-web Rscript test.R

--- a/Program/app.R
+++ b/Program/app.R
@@ -1,7 +1,4 @@
 library(shiny)
-options(shiny.host = '0.0.0.0')
-options(shiny.port = 8181)
-
 library(writexl)
 
 source('netwk_anav2.R')


### PR DESCRIPTION
Automatic deployment still doesn't work, but we can now manually deploy from the repo like this:

```
heroku container:login
heroku container:push web
heroku container:release web
heroku open
```