### PR TITLE
Fix/docker restart always

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
 install:
-	docker build -t grn-web .
+	docker build -t grn-web:latest .
 
 run-r:
-	docker run -it grn-web R
+	docker run -it grn-web:latest R
 
 run-bash:
-	docker run -v /tmp/grn-web:/tmp/grn-web -it grn-web bash
+	docker run -v /tmp/grn-web:/tmp/grn-web -it grn-web:latest bash
 
 run-shiny:
-	docker run --env PORT=8181 -p 8181:8181 -it grn-web
+	docker run --env PORT=8181 -p 8181:8181 -it grn-web:latest
 
 run-shiny-prod:
-	docker run --restart=always --env PORT=80 -p 80:80 -it grn-web
+	docker run --name grn-web --env PORT=80 -p 80:80 -d grn-web:latest
 
 test:
-	docker run -it grn-web Rscript example.R
+	docker run -it grn-web:latest Rscript example.R

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ if you need to keep your existing R installation untouched.
 ### Installation on a server
 
 After following the Docker-based installation, you can also run it on a server.
-You can use `systemd` to automatically start `GRN_web` whenever your server starts ie.g. by copying `start_grnweb_server.sh` to `/usr/local/bin/start_grnweb_server.sh` and `grn-web.service` to `/etc/systemd/system/grn-web.service`.
+You can use `systemd` to automatically start `GRN_web` whenever your server starts e.g. by copying `start_grnweb_server.sh` to `/usr/local/bin/start_grnweb_server.sh` and `grn-web.service` to `/etc/systemd/system/grn-web.service`.
 
 Afterwards, enable and start the service like this:
 
@@ -42,7 +42,7 @@ sudo systemctl start grn-web
 
 To use the web interface, change into the `./Program` directory and execute `Rscript app.R 
 It will show the URL you need to use in your browser, e.g. `http://127.0.0.1:3395`.
-Or you can use our [public server](http://grn-web.bio.uni-potsdam.de/)
+Or you can use our [public server](http://grn-web.bio.uni-potsdam.de/).
 
 ### Target predictions
 To get target predictions of a regulator you are interested in use the drop-down menu in the "Top targets and significant enriched GO terms" tab to search for its JGI Gene ID.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ if you need to keep your existing R installation untouched.
 - afterwards, you can start the container like this: `docker run --env PORT=8181 -p 8181:8181 -it grn-web`
 - now, visit http://localhost:8181/ in your browser to use GRN_web
 
+### Installation on a server
+
+After following the Docker-based installation, you can also run it on a server.
+You can use `systemd` to automatically start `GRN_web` whenever your server starts ie.g. by copying `start_grnweb_server.sh` to `/usr/local/bin/start_grnweb_server.sh` and `grn-web.service` to `/etc/systemd/system/grn-web.service`.
+
+Afterwards, enable and start the service like this:
+
+```
+sudo systemctl enable grn-web
+sudo systemctl start grn-web
+```
 
 ## Usage example
 

--- a/grn-web.service
+++ b/grn-web.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Start grn-web as a Docker container
+After=docker.service
+Requires=docker.service
+
+[Service]
+ExecStart=/usr/local/bin/start_grnweb_server.sh
+
+[Install]
+WantedBy=multi-user.target
+

--- a/start_grnweb_server.sh
+++ b/start_grnweb_server.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+docker stop grn-web
+docker rm grn-web
+docker run --name grn-web --env PORT=80 -p 80:80 -d grn-web:latest


### PR DESCRIPTION
Our server setup used `docker run --restart=always` to ensure that GRN_web always restarts itself after the (re)boots. This looks convenient, but causes all sorts of problems. Whenever you update GRN_web, docker will still try to restart the old container/image, even if you have deleted it and it is no longer visible in `docker images`.

To avoid this, we're now using `systemd`.